### PR TITLE
商品情報編集機能1

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,19 +25,19 @@ class ItemsController < ApplicationController
   def show
   end
 
-  #def edit
-    #@item = Item.find(params[:id])
-    #redirect_to root_path unless current_user == @item.user
-  #end
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user == @item.user
+  end
 
-  #def update
-    #@item = Item.find(params[:id])
-   # if @item.update(item_params)
-    #  redirect_to items_path,notice: "変更しました" 
-    #else
-     # render :edit
- #   end
-  #end
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+       redirect_to items_path,notice: "変更しました" 
+    else
+       render :edit
+    end
+  end
 
  # def destroy
    # if @item.destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,12 +26,10 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user == @item.user
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
        redirect_to items_path,notice: "変更しました" 
     else

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -83,7 +83,7 @@ app/assets/stylesheets/items/new.css %>
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all , :id ,:name , {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_days_id, ShippingDays.all , :id ,:name , {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -82,7 +82,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all , :id ,:name , {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_days_id, ShippingDays.all , :id ,:name , {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %> 
     <% else %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%= link_to '購入画面に進む', orders_path ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
     <% end %>  

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %> 
     <% else %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%=# link_to '購入画面に進む', orders_path ,class:"item-red-btn"%>
+    <%#= link_to '購入画面に進む', orders_path ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
     <% end %>  

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %> 
     <% else %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', orders_path ,class:"item-red-btn"%>
+    <%=# link_to '購入画面に進む', orders_path ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
     <% end %>  

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/second-header"%>
- <%= render 'shared/error_messages', model: @order %>
+ <%#= render 'shared/error_messages', model: @order %>
 <div class='transaction-contents'>
   <div class='transaction-main'>
     <h1 class='transaction-title-text'>
@@ -31,7 +31,7 @@
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @item, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -89,7 +89,7 @@
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+         <%= f.collection_select(:shipment_address_id, ShipmentAddress.all, :id , :name , {}, {class:"select-box", id:"item-prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/second-header"%>
-
+ <%= render 'shared/error_messages', model: @order %>
 <div class='transaction-contents'>
   <div class='transaction-main'>
     <h1 class='transaction-title-text'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'items#index'
   resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
-  resources :orders, only: [:create]
+  resources :orders, only: [:create, :index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'items#index'
   resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
-  resources :orders, only: [:create, :index]
+  #resources :orders, only: [:create, :index]
 end

--- a/db/migrate/20201210075216_create_orders.rb
+++ b/db/migrate/20201210075216_create_orders.rb
@@ -1,7 +1,14 @@
 class CreateOrders < ActiveRecord::Migration[6.0]
   def change
     create_table :orders do |t|
+      t.integer :buy_id ,foreign_key: true
       t.integer :price  ,null: false
+      t.string  :postcode ,null:false
+      t.integer :prefecture_id ,null: false
+      t.string  :municipality ,null: false
+      t.string  :address ,null: false
+      t.string  :house_number ,null: false
+      t.string  :phone_number ,null: false
       t.timestamps
     end
   end


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Why
フリマアプリ実装に必須のため

必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
[https://gyazo.com/26f2ccb2630285024ac45ccf5206bce4](url)

何も編集せずに更新をしても画像無しの商品にならないこと
ログイン状態の出品者だけが商品情報編集ページに遷移できること
商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること
[https://gyazo.com/2f6ee212fa0ad17bc483382a25409ccf](url)

エラーハンドリングができていること
[https://gyazo.com/02d336764071073a0ab35e26fff04d30](url)

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
[https://gyazo.com/052af081e0c8fa84909dbdc0d32c30dd](url)